### PR TITLE
use an environment variable to change the path (default /how-to/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Add a file called `.travis.yml` into the root of the github repository:
         - KC_DOC_ROOT=<path/to/doc/root>
         - KC_BASE_URL=<http://example.com/kc>
         - NEXUS_URL=<nexus url>
+        - URL_PATH="/how-to/"
         - secure: <NEXUS_API_KEY encrypted string>
         - secure: <GITHUB_API_TOKEN encrypted string>
 
@@ -53,6 +54,10 @@ Export the necessary env variables:
     export KC_BASE_URL=[KC_BASE_URL]
     export NEXUS_URL=[NEXUS_URL]
     export NEXUS_API_KEY=[NEXUS_API_KEY]
+
+Optionally, specify:
+
+    export URL_PATH="/how-to/"
 
 Change directory to where the kc lives, and execute the update:
 

--- a/lib/kc-preparer/command/all_articles.rb
+++ b/lib/kc-preparer/command/all_articles.rb
@@ -20,11 +20,13 @@ class KCPreparer::AllArticlesCommand < KCPreparer::Command
   end
 
   def get_permalinks(paths)
-    paths.map do |path|
-      link = '/how-to/' + File.basename(path, '.*')
+    url_path = config[:url_path] || '/how-to/'
+    result = paths.map do |path|
+      link = url_path + File.basename(path, '.*')
       document = KCPreparer::Document.new(@config, path, IO.read(path))
       {'link' => link, 'title' => document.metadata['title']}
     end
+    result.sort! { |x,y| x['title'] <=> y['title'] }
   end
 
   def generate_file(row, permalinks)

--- a/lib/kc-preparer/config.rb
+++ b/lib/kc-preparer/config.rb
@@ -14,7 +14,8 @@ class KCPreparer::Config
     'KC_DOC_ROOT',
     'KC_BASE_URL',
     'NEXUS_URL',
-    'NEXUS_API_KEY'
+    'NEXUS_API_KEY',
+    'URL_PATH'
   ]
 
   def initialize(argv)


### PR DESCRIPTION
this is useful for publishing white-papers to /white-paper/
also adds an improvement to the all-articles page, sorting by title